### PR TITLE
feat: NativeConcurrency package trait — async-only, NIO-free SQLKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,5 @@
 // swift-tools-version:6.1
-import class Foundation.ProcessInfo
 import PackageDescription
-
-// Embedded-wasm port (see /Users/scottm/git/c34/khasm/EMBEDDED_PORT_PLAN.md): with
-// KHASM_EMBEDDED=1 SwiftNIO is dropped — the Embedded build keeps only the async/`SQLBindValue`
-// SQLKit core, gated in source with `#if hasFeature(Embedded)` (not available in manifests,
-// hence the env var, matching khasm's own manifest gating). Regular builds — including regular
-// WASI, where EventLoopFuture rides NIOAsyncRuntime — keep NIO exactly as at the 3.36.0 base.
-let khasmEmbedded = ProcessInfo.processInfo.environment["KHASM_EMBEDDED"] == "1"
 
 let package = Package(
     name: "sql-kit",
@@ -21,11 +13,25 @@ let package = Package(
         .library(name: "SQLKit", targets: ["SQLKit"]),
         .library(name: "SQLKitBenchmark", targets: ["SQLKitBenchmark"]),
     ],
+    traits: [
+        .default(enabledTraits: ["NIO"]),
+        .trait(
+            name: "NIO",
+            description: "Default backend: SwiftNIO (the legacy EventLoopFuture query surface)."
+        ),
+        .trait(
+            name: "NativeConcurrency",
+            description: "NIO-free build on Swift concurrency: the EventLoopFuture overloads are removed; the async query surface is the only one. Build with `--traits NativeConcurrency` (replaces the default NIO trait)."
+        ),
+        .trait(
+            name: "Freestanding",
+            description: "Embedded/freestanding flavor (implies NativeConcurrency). No additional source effect in this package beyond NativeConcurrency; declared so a root's `--traits Freestanding` configuration names a known trait when this package is wired by path.",
+            enabledTraits: ["NativeConcurrency"]
+        ),
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
-        // Local embedded-ported swift-log clone (see /Users/scottm/git/c34/EMBEDDED_WASM_NOTES.md);
-        // the khasm graph already resolves the swift-log identity to this clone via QuantumInterface.
-        .package(path: "../swift-log"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.84.0"),
     ],
     targets: [
@@ -34,10 +40,11 @@ let package = Package(
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
-            ] + (khasmEmbedded ? [] : [
-                // Dropped on the Embedded build (KHASM_EMBEDDED=1, see note at the top).
-                .product(name: "NIOCore", package: "swift-nio"),
-            ]),
+                // The EventLoopFuture surface rides the default `NIO` trait; with
+                // `NativeConcurrency` enabled instead, SQLKit is NIO-free (async-only),
+                // gated in source with `#if NativeConcurrency`.
+                .product(name: "NIOCore", package: "swift-nio", condition: .when(traits: ["NIO"])),
+            ],
             swiftSettings: swiftSettings
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,13 @@
 // swift-tools-version:6.1
+import class Foundation.ProcessInfo
 import PackageDescription
+
+// Embedded-wasm port (see /Users/scottm/git/c34/khasm/EMBEDDED_PORT_PLAN.md): with
+// KHASM_EMBEDDED=1 SwiftNIO is dropped — the Embedded build keeps only the async/`SQLBindValue`
+// SQLKit core, gated in source with `#if hasFeature(Embedded)` (not available in manifests,
+// hence the env var, matching khasm's own manifest gating). Regular builds — including regular
+// WASI, where EventLoopFuture rides NIOAsyncRuntime — keep NIO exactly as at the 3.36.0 base.
+let khasmEmbedded = ProcessInfo.processInfo.environment["KHASM_EMBEDDED"] == "1"
 
 let package = Package(
     name: "sql-kit",
@@ -15,7 +23,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4"),
+        // Local embedded-ported swift-log clone (see /Users/scottm/git/c34/EMBEDDED_WASM_NOTES.md);
+        // the khasm graph already resolves the swift-log identity to this clone via QuantumInterface.
+        .package(path: "../swift-log"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.84.0"),
     ],
     targets: [
@@ -24,8 +34,10 @@ let package = Package(
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
+            ] + (khasmEmbedded ? [] : [
+                // Dropped on the Embedded build (KHASM_EMBEDDED=1, see note at the top).
                 .product(name: "NIOCore", package: "swift-nio"),
-            ],
+            ]),
             swiftSettings: swiftSettings
         ),
         .target(

--- a/Sources/SQLKit/Builders/Implementations/SQLAlterTableBuilder.swift
+++ b/Sources/SQLKit/Builders/Implementations/SQLAlterTableBuilder.swift
@@ -45,7 +45,9 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
     @inlinable
     @discardableResult
     public func column(_ column: String, type dataType: SQLDataType, _ constraints: [SQLColumnConstraintAlgorithm]) -> Self {
-        self.column(SQLIdentifier(column), type: dataType, constraints)
+        // Box each element explicitly: the implicit `[Concrete]`→`[any SQLExpression]` array
+        // conversion is a dynamic cast, which Embedded Swift forbids.
+        self.column(SQLIdentifier(column), type: dataType, constraints.map { $0 as any SQLExpression })
     }
     
     /// Add a new column to the table.
@@ -81,7 +83,7 @@ public final class SQLAlterTableBuilder: SQLQueryBuilder {
     @inlinable
     @discardableResult
     public func modifyColumn(_ column: String, type dataType: SQLDataType, _ constraints: [SQLColumnConstraintAlgorithm]) -> Self {
-        self.modifyColumn(SQLIdentifier(column), type: dataType, constraints)
+        self.modifyColumn(SQLIdentifier(column), type: dataType, constraints.map { $0 as any SQLExpression })
     }
     
     /// Change an existing column's type and constraints.

--- a/Sources/SQLKit/Builders/Implementations/SQLConflictUpdateBuilder.swift
+++ b/Sources/SQLKit/Builders/Implementations/SQLConflictUpdateBuilder.swift
@@ -32,6 +32,8 @@ public final class SQLConflictUpdateBuilder: SQLColumnUpdateBuilder, SQLPredicat
         return self
     }
     
+    // Codable model encoding (SQLQueryEncoder) is unavailable in Embedded Swift.
+    #if !hasFeature(Embedded)
     /// Encodes the given `Encodable` value to a sequence of key-value pairs and adds an assignment
     /// for each pair which uses the values each column was given in the original `INSERT` query's
     /// `VALUES` list.
@@ -46,7 +48,7 @@ public final class SQLConflictUpdateBuilder: SQLColumnUpdateBuilder, SQLPredicat
     @inlinable
     @discardableResult
     public func set(
-        excludedContentOf model: some Encodable & Sendable,
+        excludedContentOf model: some SQLBindable & Sendable,
         prefix: String? = nil,
         keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys,
         nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .default,
@@ -70,9 +72,10 @@ public final class SQLConflictUpdateBuilder: SQLColumnUpdateBuilder, SQLPredicat
     @inlinable
     @discardableResult
     public func set(
-        excludedContentOf model: some Encodable & Sendable,
+        excludedContentOf model: some SQLBindable & Sendable,
         with encoder: SQLQueryEncoder
     ) throws -> Self {
         try encoder.encode(model).reduce(self) { $0.set(excludedValueOf: $1.0) }
     }
+    #endif  // !hasFeature(Embedded)
 }

--- a/Sources/SQLKit/Builders/Implementations/SQLCreateTableBuilder.swift
+++ b/Sources/SQLKit/Builders/Implementations/SQLCreateTableBuilder.swift
@@ -37,7 +37,7 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
     @inlinable
     @discardableResult
     public func column(_ column: String, type dataType: SQLDataType, _ constraints: [SQLColumnConstraintAlgorithm]) -> Self {
-        self.column(SQLIdentifier(column), type: dataType, constraints)
+        self.column(SQLIdentifier(column), type: dataType, constraints.map { $0 as any SQLExpression })
     }
     
     /// Add a new column by name, type, and constraints.
@@ -66,7 +66,9 @@ public final class SQLCreateTableBuilder: SQLQueryBuilder {
     @inlinable
     @discardableResult
     public func column(definitions: [SQLColumnDefinition]) -> SQLCreateTableBuilder {
-        self.columns.append(contentsOf: definitions)
+        // Box each element explicitly: the implicit `[Concrete]`→`[any SQLExpression]` array
+        // conversion is a dynamic cast, which Embedded Swift forbids.
+        self.columns.append(contentsOf: definitions.map { $0 as any SQLExpression })
         return self
     }
 
@@ -125,7 +127,9 @@ extension SQLCreateTableBuilder {
     @inlinable
     @discardableResult
     public func primaryKey(_ columns: [String], named constraintName: String? = nil) -> Self {
-        self.primaryKey(columns.map(SQLIdentifier.init(_:)), named: constraintName.map(SQLIdentifier.init(_:)))
+        // Box each element to `any SQLExpression`: the implicit `[Concrete]`/`Concrete?` →
+        // `[any SQLExpression]`/`(any SQLExpression)?` conversions are dynamic casts (forbidden in embedded).
+        self.primaryKey(columns.map { SQLIdentifier($0) as any SQLExpression }, named: constraintName.map { SQLIdentifier($0) as any SQLExpression })
     }
 
     /// Add a `PRIMARY KEY` constraint to the table.
@@ -162,7 +166,7 @@ extension SQLCreateTableBuilder {
     @inlinable
     @discardableResult
     public func unique(_ columns: [String], named constraintName: String? = nil) -> Self {
-        self.unique(columns.map(SQLIdentifier.init(_:)), named: constraintName.map(SQLIdentifier.init(_:)))
+        self.unique(columns.map { SQLIdentifier($0) as any SQLExpression }, named: constraintName.map { SQLIdentifier($0) as any SQLExpression })
     }
 
     /// Add a `UNIQUE` constraint to the table.
@@ -188,7 +192,7 @@ extension SQLCreateTableBuilder {
     @inlinable
     @discardableResult
     public func check(_ expression: any SQLExpression, named constraintName: String? = nil) -> Self {
-        self.check(expression, named: constraintName.map(SQLIdentifier.init(_:)))
+        self.check(expression, named: constraintName.map { SQLIdentifier($0) as any SQLExpression })
     }
 
     /// Add a `CHECK` constraint to the table.
@@ -226,10 +230,10 @@ extension SQLCreateTableBuilder {
         named constraintName: String? = nil
     ) -> Self {
         self.foreignKey(
-            columns.map(SQLIdentifier.init(_:)),
-            references: SQLIdentifier(foreignTable), foreignColumns.map(SQLIdentifier.init(_:)),
+            columns.map { SQLIdentifier($0) as any SQLExpression },
+            references: SQLIdentifier(foreignTable), foreignColumns.map { SQLIdentifier($0) as any SQLExpression },
             onDelete: onDelete, onUpdate: onUpdate,
-            named: constraintName.map(SQLIdentifier.init(_:))
+            named: constraintName.map { SQLIdentifier($0) as any SQLExpression }
         )
     }
 

--- a/Sources/SQLKit/Builders/Implementations/SQLCreateTriggerBuilder.swift
+++ b/Sources/SQLKit/Builders/Implementations/SQLCreateTriggerBuilder.swift
@@ -52,7 +52,7 @@ public final class SQLCreateTriggerBuilder: SQLQueryBuilder {
     @inlinable
     @discardableResult
     public func columns(_ columns: [String]) -> Self {
-        self.columns(columns.map(SQLIdentifier.init(_:)))
+        self.columns(columns.map { SQLIdentifier($0) as any SQLExpression })
     }
 
     /// Specify the columns to which the trigger applies.

--- a/Sources/SQLKit/Builders/Implementations/SQLInsertBuilder.swift
+++ b/Sources/SQLKit/Builders/Implementations/SQLInsertBuilder.swift
@@ -39,6 +39,8 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder/*, SQL
         self.database = database
     }
     
+    // Codable model encoding (SQLQueryEncoder) is unavailable in Embedded Swift.
+    #if !hasFeature(Embedded)
     /// Use an `Encodable` value to generate a row to insert and add that row to the query.
     ///
     /// Example usage:
@@ -216,7 +218,8 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder/*, SQL
         }
         return self
     }
-    
+    #endif  // !hasFeature(Embedded)
+
     /// Specify mutiple columns to be included in the list of columns for the query.
     ///
     /// Overwrites any previously specified column list.
@@ -232,7 +235,7 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder/*, SQL
     @inlinable
     @discardableResult
     public func columns(_ columns: [String]) -> Self {
-        self.columns(columns.map(SQLIdentifier.init(_:)))
+        self.columns(columns.map { SQLIdentifier($0) as any SQLExpression })
     }
     
     /// Specify mutiple columns to be included in the list of columns for the query.
@@ -258,15 +261,15 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder/*, SQL
     @inlinable
     @discardableResult
     @_disfavoredOverload
-    public func values(_ values: any Encodable & Sendable...) -> Self {
+    public func values(_ values: any SQLBindable & Sendable...) -> Self {
         self.values(values)
     }
     
     /// Add a set of values to be inserted as a single row.
     @inlinable
     @discardableResult
-    public func values(_ values: [any Encodable & Sendable]) -> Self {
-        self.values(values.map { SQLBind($0) })
+    public func values(_ values: [any SQLBindable & Sendable]) -> Self {
+        self.values(values.map { SQLBind($0) as any SQLExpression })
     }
     
     /// Add a set of values to be inserted as a single row.
@@ -334,7 +337,7 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder/*, SQL
     @inlinable
     @discardableResult
     public func ignoringConflicts(with targetColumns: [String] = []) -> Self {
-        self.ignoringConflicts(with: targetColumns.map(SQLIdentifier.init(_:)))
+        self.ignoringConflicts(with: targetColumns.map { SQLIdentifier($0) as any SQLExpression })
     }
 
     /// Specify that constraint violations for the key over the given columns should cause the conflicting
@@ -365,7 +368,7 @@ public final class SQLInsertBuilder: SQLQueryBuilder, SQLReturningBuilder/*, SQL
         with targetColumns: [String] = [],
         `do` updatePredicate: (SQLConflictUpdateBuilder) throws -> SQLConflictUpdateBuilder
     ) rethrows -> Self {
-        try self.onConflict(with: targetColumns.map(SQLIdentifier.init(_:)), do: updatePredicate)
+        try self.onConflict(with: targetColumns.map { SQLIdentifier($0) as any SQLExpression }, do: updatePredicate)
     }
     
     /// Specify that constraint violations for the key over the given column should cause the conflicting

--- a/Sources/SQLKit/Builders/Prototypes/SQLColumnUpdateBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLColumnUpdateBuilder.swift
@@ -7,6 +7,8 @@ public protocol SQLColumnUpdateBuilder: AnyObject {
 }
 
 extension SQLColumnUpdateBuilder {
+    // Codable model encoding (SQLQueryEncoder) is unavailable in Embedded Swift.
+    #if !hasFeature(Embedded)
     /// Using a default-configured ``SQLQueryEncoder``, transform the provided model into a series of key/value
     /// pairs and add an assignment for each pair.
     ///
@@ -15,7 +17,7 @@ extension SQLColumnUpdateBuilder {
     /// - Parameter model: An `Encodable` value whose keys and values will form a series of column assignments.
     @inlinable
     @discardableResult
-    public func set(model: some Encodable & Sendable) throws -> Self {
+    public func set(model: some SQLBindable & Sendable) throws -> Self {
         try self.set(model: model, with: .init())
     }
 
@@ -33,7 +35,7 @@ extension SQLColumnUpdateBuilder {
     @inlinable
     @discardableResult
     public func set(
-        model: some Encodable & Sendable,
+        model: some SQLBindable & Sendable,
         prefix: String? = nil,
         keyEncodingStrategy: SQLQueryEncoder.KeyEncodingStrategy = .useDefaultKeys,
         nilEncodingStrategy: SQLQueryEncoder.NilEncodingStrategy = .default,
@@ -61,11 +63,12 @@ extension SQLColumnUpdateBuilder {
     @inlinable
     @discardableResult
     public func set(
-        model: some Encodable & Sendable,
+        model: some SQLBindable & Sendable,
         with encoder: SQLQueryEncoder
     ) throws -> Self {
         try encoder.encode(model).reduce(self) { $0.set(SQLColumn($1.0), to: $1.1) }
     }
+    #endif  // !hasFeature(Embedded)
 
     /// Add an assignment setting the named column to the provided `Encodable` value.
     ///
@@ -76,7 +79,7 @@ extension SQLColumnUpdateBuilder {
     ///   - bind: The value to assign to the named column.
     @inlinable
     @discardableResult
-    public func set(_ column: String, to bind: any Encodable & Sendable) -> Self {
+    public func set(_ column: String, to bind: any SQLBindable & Sendable) -> Self {
         self.set(SQLColumn(column), to: SQLBind(bind))
     }
     
@@ -102,7 +105,7 @@ extension SQLColumnUpdateBuilder {
     ///   - bind: The value to assign to the given column.
     @inlinable
     @discardableResult
-    public func set(_ column: any SQLExpression, to bind: any Encodable & Sendable) -> Self {
+    public func set(_ column: any SQLExpression, to bind: any SQLBindable & Sendable) -> Self {
         self.set(column, to: SQLBind(bind))
     }
     

--- a/Sources/SQLKit/Builders/Prototypes/SQLCommonTableExpressionBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLCommonTableExpressionBuilder.swift
@@ -34,7 +34,7 @@ extension SQLCommonTableExpressionBuilder {
     @inlinable
     @discardableResult
     public func with(_ name: some StringProtocol, columns: [String], as query: some SQLExpression) -> Self {
-        self.with(name, columns: columns.map(SQLIdentifier.init(_:)), as: query)
+        self.with(name, columns: columns.map { SQLIdentifier($0) as any SQLExpression }, as: query)
     }
 
     /// Specify a subquery to include as a _recursive_ common table expression, for use elsewhere in
@@ -70,7 +70,7 @@ extension SQLCommonTableExpressionBuilder {
     @inlinable
     @discardableResult
     public func with(recursive name: some StringProtocol, columns: [String], as query: some SQLExpression) -> Self {
-        self.with(recursive: name, columns: columns.map(SQLIdentifier.init(_:)), as: query)
+        self.with(recursive: name, columns: columns.map { SQLIdentifier($0) as any SQLExpression }, as: query)
     }
 
     // MARK: - String name, expression columns
@@ -170,7 +170,7 @@ extension SQLCommonTableExpressionBuilder {
     @inlinable
     @discardableResult
     public func with(_ name: some SQLExpression, columns: [String], as query: some SQLExpression) -> Self {
-        self.with(name, columns: columns.map(SQLIdentifier.init(_:)), as: query)
+        self.with(name, columns: columns.map { SQLIdentifier($0) as any SQLExpression }, as: query)
     }
 
     /// Specify a subquery to include as a _recursive_ common table expression, for use elsewhere in
@@ -206,7 +206,7 @@ extension SQLCommonTableExpressionBuilder {
     @inlinable
     @discardableResult
     public func with(recursive name: some SQLExpression, columns: [String], as query: some SQLExpression) -> Self {
-        self.with(recursive: name, columns: columns.map(SQLIdentifier.init(_:)), as: query)
+        self.with(recursive: name, columns: columns.map { SQLIdentifier($0) as any SQLExpression }, as: query)
     }
 
     // MARK: - Expression name, expression columns

--- a/Sources/SQLKit/Builders/Prototypes/SQLPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLPredicateBuilder.swift
@@ -23,7 +23,7 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM "planets" WHERE "name" = $0 ["Earth"]
     @inlinable
     @discardableResult
-    public func `where`(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func `where`(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.where(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
@@ -36,8 +36,8 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM "planets" WHERE "name" IN ($0, $1) ["Earth", "Mars"]
     @inlinable
     @discardableResult
-    public func `where`(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.where(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func `where`(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.where(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     /// Adds a column to encodable comparison to this builder's `WHERE` clause by `AND`ing.
@@ -49,7 +49,7 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM "planets" WHERE "name" = $0 ["Earth"]
     @inlinable
     @discardableResult
-    public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.where(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
@@ -62,8 +62,8 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM "planets" WHERE "name" IN ($0, $1) ["Earth", "Mars"]
     @inlinable
     @discardableResult
-    public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.where(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func `where`(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.where(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     // MARK: - Column/column comparison
@@ -154,7 +154,7 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM "planets" WHERE "name" = $0 ["Earth"]
     @inlinable
     @discardableResult
-    public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.orWhere(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
@@ -167,22 +167,22 @@ extension SQLPredicateBuilder {
     ///     SELECT * FROM "planets" WHERE "name" IN ($0, $1) ["Earth", "Mars"]
     @inlinable
     @discardableResult
-    public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.orWhere(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func orWhere(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.orWhere(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     /// Adds a column to encodable comparison to this builder's `WHERE` clause by `OR`ing.
     @inlinable
     @discardableResult
-    public func orWhere(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func orWhere(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.orWhere(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
     /// Adds a column to encodable array comparison to this builder's `WHERE` clause by `OR`ing.
     @inlinable
     @discardableResult
-    public func orWhere(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.orWhere(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func orWhere(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.orWhere(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     // MARK: - Column/column comparison

--- a/Sources/SQLKit/Builders/Prototypes/SQLQueryBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLQueryBuilder.swift
@@ -1,5 +1,5 @@
-// EventLoopFuture is elided on WASI (the WASI build is NIO-free / async).
-#if !hasFeature(Embedded)
+// EventLoopFuture is elided on the NativeConcurrency (NIO-free) build.
+#if !NativeConcurrency
 import class NIOCore.EventLoopFuture
 #endif
 
@@ -17,7 +17,7 @@ public protocol SQLQueryBuilder: AnyObject {
     ///
     /// Although it is a protocol requirement for historical reasons, this is considered a legacy interface
     /// thanks to its reliance on `EventLoopFuture`. Users should call ``run()-3tldd`` whenever possible.
-    #if !hasFeature(Embedded)
+    #if !NativeConcurrency
     func run() -> EventLoopFuture<Void>
     #endif
 
@@ -30,7 +30,7 @@ extension SQLQueryBuilder {
     /// Execute the query associated with the builder on the builder's database, ignoring any results.
     ///
     /// See ``SQLQueryFetcher`` for methods which retrieve results from a query.
-    #if !hasFeature(Embedded)
+    #if !NativeConcurrency
     @inlinable
     public func run() -> EventLoopFuture<Void> {
         self.database.execute(sql: self.query) { _ in }

--- a/Sources/SQLKit/Builders/Prototypes/SQLQueryBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLQueryBuilder.swift
@@ -1,4 +1,7 @@
+// EventLoopFuture is elided on WASI (the WASI build is NIO-free / async).
+#if !hasFeature(Embedded)
 import class NIOCore.EventLoopFuture
+#endif
 
 /// Base definitions for builders which set up queries and execute them against a given database.
 ///
@@ -6,7 +9,7 @@ import class NIOCore.EventLoopFuture
 public protocol SQLQueryBuilder: AnyObject {
     /// Query being built.
     var query: any SQLExpression { get }
-    
+
     /// Connection to execute query on.
     var database: any SQLDatabase { get }
 
@@ -14,8 +17,10 @@ public protocol SQLQueryBuilder: AnyObject {
     ///
     /// Although it is a protocol requirement for historical reasons, this is considered a legacy interface
     /// thanks to its reliance on `EventLoopFuture`. Users should call ``run()-3tldd`` whenever possible.
+    #if !hasFeature(Embedded)
     func run() -> EventLoopFuture<Void>
-    
+    #endif
+
     /// Execute the query on the connection, ignoring any results.
     func run() async throws
 
@@ -25,10 +30,12 @@ extension SQLQueryBuilder {
     /// Execute the query associated with the builder on the builder's database, ignoring any results.
     ///
     /// See ``SQLQueryFetcher`` for methods which retrieve results from a query.
+    #if !hasFeature(Embedded)
     @inlinable
     public func run() -> EventLoopFuture<Void> {
         self.database.execute(sql: self.query) { _ in }
     }
+    #endif
 
     /// Execute the query associated with the builder on the builder's database, ignoring any results.
     ///

--- a/Sources/SQLKit/Builders/Prototypes/SQLQueryFetcher.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLQueryFetcher.swift
@@ -1,10 +1,15 @@
+// EventLoopFuture is elided on WASI; the `<D: Decodable>` decoding variants are elided in Embedded
+// Swift (no Codable). The raw async `first()`/`all()`/`run(_:)` over `any SQLRow` remain available.
+#if !hasFeature(Embedded)
 import class NIOCore.EventLoopFuture
+#endif
 
 /// Common definitions for ``SQLQueryBuilder``s which support retrieving result rows.
 public protocol SQLQueryFetcher: SQLQueryBuilder {}
 
 // MARK: - First (EventLoopFuture)
 
+#if !hasFeature(Embedded)
 extension SQLQueryFetcher {
     /// Returns the named column from the first output row, if any, decoded as a given type.
     ///
@@ -70,9 +75,12 @@ extension SQLQueryFetcher {
     }
 }
 
+#endif  // !hasFeature(Embedded)
+
 // MARK: - First (async)
 
 extension SQLQueryFetcher {
+    #if !hasFeature(Embedded)
     /// Returns the named column from the first output row, if any, decoded as a given type.
     ///
     /// - Parameters:
@@ -122,6 +130,7 @@ extension SQLQueryFetcher {
     public func first<D: Decodable>(decoding type: D.Type, with decoder: SQLRowDecoder) async throws -> D? {
         try await self.first()?.decode(model: D.self, with: decoder)
     }
+    #endif  // !hasFeature(Embedded)
 
     /// Returns the first output row, if any.
     /// 
@@ -131,7 +140,11 @@ extension SQLQueryFetcher {
     /// - Returns: The first output row, if any.
     @inlinable
     public func first() async throws -> (any SQLRow)? {
+        // `as?` to a different existential is a dynamic cast (unavailable in embedded); skip the
+        // LIMIT-1 optimization there (correctness is unaffected; we just fetch and take the first).
+        #if !hasFeature(Embedded)
         (self as? any SQLPartialResultBuilder)?.limit(1)
+        #endif
         nonisolated(unsafe) var rows = [any SQLRow]()
         try await self.run { if rows.isEmpty { rows.append($0) } }
         return rows.first
@@ -140,6 +153,7 @@ extension SQLQueryFetcher {
 
 // MARK: - All (EventLoopFuture)
 
+#if !hasFeature(Embedded)
 extension SQLQueryFetcher {
     /// Returns the named column from each output row, if any, decoded as a given type.
     ///
@@ -201,9 +215,12 @@ extension SQLQueryFetcher {
     }
 }
 
+#endif  // !hasFeature(Embedded)
+
 // MARK: - All (async)
 
 extension SQLQueryFetcher {
+    #if !hasFeature(Embedded)
     /// Returns the named column from each output row, if any, decoded as a given type.
     ///
     /// - Parameters:
@@ -253,6 +270,7 @@ extension SQLQueryFetcher {
     public func all<D: Decodable>(decoding type: D.Type, with decoder: SQLRowDecoder) async throws -> [D] {
         try await self.all().map { try $0.decode(model: D.self, with: decoder) }
     }
+    #endif  // !hasFeature(Embedded)
 
     /// Returns all output rows, if any.
     ///
@@ -267,6 +285,7 @@ extension SQLQueryFetcher {
 
 // MARK: - Run (EventLoopFuture)
 
+#if !hasFeature(Embedded)
 extension SQLQueryFetcher {
     /// Using a default-configured ``SQLRowDecoder``, call the provided handler closure with the result of decoding
     /// each output row, if any, as a given type.
@@ -333,9 +352,12 @@ extension SQLQueryFetcher {
     }
 }
 
+#endif  // !hasFeature(Embedded)
+
 // MARK: - Run (async)
 
 extension SQLQueryFetcher {
+    #if !hasFeature(Embedded)
     /// Using a default-configured ``SQLRowDecoder``, call the provided handler closure with the result of decoding
     /// each output row, if any, as a given type.
     ///
@@ -384,6 +406,7 @@ extension SQLQueryFetcher {
     ) async throws {
         try await self.run { row in handler(Result { try row.decode(model: D.self, with: decoder) }) }
     }
+    #endif  // !hasFeature(Embedded)
 
     /// Run the query specified by the builder, calling the provided handler closure with each output row, if any, as
     /// it is received.

--- a/Sources/SQLKit/Builders/Prototypes/SQLQueryFetcher.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLQueryFetcher.swift
@@ -1,6 +1,7 @@
-// EventLoopFuture is elided on WASI; the `<D: Decodable>` decoding variants are elided in Embedded
-// Swift (no Codable). The raw async `first()`/`all()`/`run(_:)` over `any SQLRow` remain available.
-#if !hasFeature(Embedded)
+// EventLoopFuture is elided on the NativeConcurrency (NIO-free) build; the `<D: Decodable>`
+// decoding variants are elided in Embedded Swift (no Codable). The raw async
+// `first()`/`all()`/`run(_:)` over `any SQLRow` remain available everywhere.
+#if !NativeConcurrency
 import class NIOCore.EventLoopFuture
 #endif
 
@@ -9,7 +10,7 @@ public protocol SQLQueryFetcher: SQLQueryBuilder {}
 
 // MARK: - First (EventLoopFuture)
 
-#if !hasFeature(Embedded)
+#if !NativeConcurrency
 extension SQLQueryFetcher {
     /// Returns the named column from the first output row, if any, decoded as a given type.
     ///
@@ -75,7 +76,7 @@ extension SQLQueryFetcher {
     }
 }
 
-#endif  // !hasFeature(Embedded)
+#endif  // !NativeConcurrency
 
 // MARK: - First (async)
 
@@ -153,7 +154,7 @@ extension SQLQueryFetcher {
 
 // MARK: - All (EventLoopFuture)
 
-#if !hasFeature(Embedded)
+#if !NativeConcurrency
 extension SQLQueryFetcher {
     /// Returns the named column from each output row, if any, decoded as a given type.
     ///
@@ -215,7 +216,7 @@ extension SQLQueryFetcher {
     }
 }
 
-#endif  // !hasFeature(Embedded)
+#endif  // !NativeConcurrency
 
 // MARK: - All (async)
 
@@ -285,7 +286,7 @@ extension SQLQueryFetcher {
 
 // MARK: - Run (EventLoopFuture)
 
-#if !hasFeature(Embedded)
+#if !NativeConcurrency
 extension SQLQueryFetcher {
     /// Using a default-configured ``SQLRowDecoder``, call the provided handler closure with the result of decoding
     /// each output row, if any, as a given type.
@@ -352,7 +353,7 @@ extension SQLQueryFetcher {
     }
 }
 
-#endif  // !hasFeature(Embedded)
+#endif  // !NativeConcurrency
 
 // MARK: - Run (async)
 

--- a/Sources/SQLKit/Builders/Prototypes/SQLReturningBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLReturningBuilder.swift
@@ -10,7 +10,7 @@ extension SQLReturningBuilder {
     /// - Returns: A ``SQLReturningResultBuilder`` which must be used to execute the query.
     @inlinable
     public func returning(_ columns: String...) -> SQLReturningResultBuilder<Self> {
-        self.returning(columns.map { SQLColumn($0 == "*" ? SQLLiteral.all : SQLIdentifier($0)) })
+        self.returning(columns.map { SQLColumn($0 == "*" ? SQLLiteral.all : SQLIdentifier($0)) as any SQLExpression })
     }
 
     /// Specify a list of columns to be returned as the result of the query.

--- a/Sources/SQLKit/Builders/Prototypes/SQLSecondaryPredicateBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLSecondaryPredicateBuilder.swift
@@ -23,7 +23,7 @@ extension SQLSecondaryPredicateBuilder {
     ///     SELECT * FROM "planets" HAVING "name" = $0 ["Earth"]
     @inlinable
     @discardableResult
-    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.having(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
@@ -36,8 +36,8 @@ extension SQLSecondaryPredicateBuilder {
     ///     SELECT * FROM "planets" HAVING "name" IN ($0, $1) ["Earth", "Mars"]
     @inlinable
     @discardableResult
-    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.having(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func having(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.having(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     /// Adds a column to encodable comparison to this builder's `HAVING` clause by `AND`ing.
@@ -49,7 +49,7 @@ extension SQLSecondaryPredicateBuilder {
     ///     SELECT * FROM "planets" HAVING "name" = $0 ["Earth"]
     @inlinable
     @discardableResult
-    public func having(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func having(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.having(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
@@ -62,8 +62,8 @@ extension SQLSecondaryPredicateBuilder {
     ///     SELECT * FROM "planets" HAVING "name" IN ($0, $1) ["Earth", "Mars"]
     @inlinable
     @discardableResult
-    public func having(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.having(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func having(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.having(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     // MARK: - Column/column comparison
@@ -148,29 +148,29 @@ extension SQLSecondaryPredicateBuilder {
     /// Adds a column to encodable comparison to this builder's `HAVING` clause by `OR`ing.
     @inlinable
     @discardableResult
-    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.orHaving(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
     /// Adds a column to encodable array comparison to this builder's `HAVING` clause by `OR`ing.
     @inlinable
     @discardableResult
-    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.orHaving(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func orHaving(_ lhs: String, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.orHaving(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     /// Adds a column to encodable comparison to this builder's `HAVING` clause by `OR`ing.
     @inlinable
     @discardableResult
-    public func orHaving(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some Encodable & Sendable) -> Self {
+    public func orHaving(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: some SQLBindable & Sendable) -> Self {
         self.orHaving(SQLColumn(lhs), op, SQLBind(rhs))
     }
 
     /// Adds a column to encodable array comparison to this builder's `HAVING` clause by `OR`ing.
     @inlinable
     @discardableResult
-    public func orHaving(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some Encodable & Sendable]) -> Self {
-        self.orHaving(SQLColumn(lhs), op, SQLBind.group(rhs))
+    public func orHaving(_ lhs: SQLIdentifier, _ op: SQLBinaryOperator, _ rhs: [some SQLBindable & Sendable]) -> Self {
+        self.orHaving(SQLColumn(lhs), op, SQLBind.group(rhs.map { $0 as any SQLBindable & Sendable }))
     }
 
     // MARK: - Column/column comparison

--- a/Sources/SQLKit/Builders/Prototypes/SQLSubqueryClauseBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLSubqueryClauseBuilder.swift
@@ -97,7 +97,7 @@ extension SQLSubqueryClauseBuilder {
     @inlinable
     @discardableResult
     public func distinct(on column: String, _ columns: String...) -> Self {
-        self.distinct(on: ([column] + columns).map(SQLIdentifier.init(_:)))
+        self.distinct(on: ([column] + columns).map { SQLIdentifier($0) as any SQLExpression })
     }
     
     /// Adds a `DISTINCT` clause to the select statement and explicitly specifies columns to select,

--- a/Sources/SQLKit/Builders/Prototypes/SQLUnqualifiedColumnListBuilder.swift
+++ b/Sources/SQLKit/Builders/Prototypes/SQLUnqualifiedColumnListBuilder.swift
@@ -36,7 +36,7 @@ extension SQLUnqualifiedColumnListBuilder {
     @inlinable
     @discardableResult
     public func columns(_ columns: [String]) -> Self {
-        self.columns(columns.map { SQLColumn($0) })
+        self.columns(columns.map { SQLColumn($0) as any SQLExpression })
     }
 
     /// Specify mutiple columns to be included in the list of columns for the query.

--- a/Sources/SQLKit/Database/SQLDatabase.swift
+++ b/Sources/SQLKit/Database/SQLDatabase.swift
@@ -1,5 +1,8 @@
+// EventLoop/EventLoopFuture are elided on WASI (the WASI build is NIO-free / async).
+#if !hasFeature(Embedded)
 import protocol NIOCore.EventLoop
 import class NIOCore.EventLoopFuture
+#endif
 import struct Logging.Logger
 
 /// The common interface to SQLKit for both drivers and client code.
@@ -62,8 +65,10 @@ public protocol SQLDatabase: Sendable {
     /// assigns loops to connections at point of use, or because the underlying implementation is based on Swift
     /// Concurrency or some other asynchronous execution technology), a single consistent `EventLoop` must be chosen
     /// for the database and returned for this property nonetheless.
+    #if !hasFeature(Embedded)
     var eventLoop: any EventLoop { get }
-    
+    #endif
+
     /// The version number the database reports for itself.
     ///
     /// The version must be provided via a type conforming to the ``SQLDatabaseReportedVersion`` protocol. If the
@@ -113,11 +118,13 @@ public protocol SQLDatabase: Sendable {
     ///   - query: An ``SQLExpression`` representing a complete query to execute.
     ///   - onRow: A closure which is invoked once for each result row returned by the query (if any).
     /// - Returns: An `EventLoopFuture`.
+    #if !hasFeature(Embedded)
     @preconcurrency
     func execute(
         sql query: any SQLExpression,
         _ onRow: @escaping @Sendable (any SQLRow) -> ()
     ) -> EventLoopFuture<Void>
+    #endif
 
     /// Requests that the given generic SQL query be serialized and executed on the database, and that
     /// the `onRow` closure be invoked once for each result row the query returns (if any).
@@ -145,9 +152,13 @@ public protocol SQLDatabase: Sendable {
     /// - Parameter closure: A closure to invoke. The single parameter shall be an implementation of ``SQLDatabase``
     ///   which represents a single "session". Implementations may pass the same database on which this method was
     ///   originally invoked.
+    // Generic method requirements can't be placed in a witness table in Embedded Swift (it would
+    // block `any SQLDatabase`); provided as an extension default below instead.
+    #if !hasFeature(Embedded)
     func withSession<R>(
         _ closure: @escaping @Sendable (any SQLDatabase) async throws -> R
     ) async throws -> R
+    #endif
 }
 
 extension SQLDatabase {
@@ -171,7 +182,7 @@ extension SQLDatabase {
     ///
     /// 1. A string containing raw SQL text rendered in the database's dialect, and,
     /// 2. A potentially empty array of values for any bound parameters referenced by the query.
-    public func serialize(_ expression: any SQLExpression) -> (sql: String, binds: [any Encodable & Sendable]) {
+    public func serialize(_ expression: any SQLExpression) -> (sql: String, binds: [any SQLBindable & Sendable]) {
         var serializer = SQLSerializer(database: self)
         expression.serialize(to: &serializer)
         return (serializer.sql, serializer.binds)
@@ -200,7 +211,9 @@ extension SQLDatabase {
 }
 
 extension SQLDatabase {
-    /// The default implementation for ``execute(sql:_:)-4eg19``.
+    /// The default implementation for ``execute(sql:_:)-4eg19`` (bridges the legacy EventLoopFuture
+    /// API). On WASI there is no EventLoopFuture overload, so conformers implement async execute directly.
+    #if !hasFeature(Embedded)
     @inlinable
     public func execute(
         sql query: any SQLExpression,
@@ -208,7 +221,8 @@ extension SQLDatabase {
     ) async throws {
         try await self.execute(sql: query, onRow).get()
     }
-    
+    #endif
+
     /// The default implementation for ``withSession(_:)-9b68j``.
     @inlinable
     public func withSession<R>(
@@ -227,10 +241,12 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
     // See `SQLDatabase.logger`.
     let logger: Logger
     
+    #if !hasFeature(Embedded)
     // See `SQLDatabase.eventLoop`.
     var eventLoop: any EventLoop {
         self.database.eventLoop
     }
+    #endif
 
     // See `SQLDatabase.version`.
     var version: (any SQLDatabaseReportedVersion)? {
@@ -247,6 +263,7 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
         self.database.queryLogLevel
     }
     
+    #if !hasFeature(Embedded)
     // See `SQLDatabase.execute(sql:_:)`.
     func execute(
         sql query: any SQLExpression,
@@ -254,6 +271,7 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
     ) -> EventLoopFuture<Void> {
         self.database.execute(sql: query, onRow)
     }
+    #endif
 
     // See `SQLDatabase.execute(sql:_:)`.
     func execute(

--- a/Sources/SQLKit/Database/SQLDatabase.swift
+++ b/Sources/SQLKit/Database/SQLDatabase.swift
@@ -1,5 +1,5 @@
-// EventLoop/EventLoopFuture are elided on WASI (the WASI build is NIO-free / async).
-#if !hasFeature(Embedded)
+// EventLoop/EventLoopFuture are elided on the NativeConcurrency (NIO-free) build.
+#if !NativeConcurrency
 import protocol NIOCore.EventLoop
 import class NIOCore.EventLoopFuture
 #endif
@@ -65,7 +65,7 @@ public protocol SQLDatabase: Sendable {
     /// assigns loops to connections at point of use, or because the underlying implementation is based on Swift
     /// Concurrency or some other asynchronous execution technology), a single consistent `EventLoop` must be chosen
     /// for the database and returned for this property nonetheless.
-    #if !hasFeature(Embedded)
+    #if !NativeConcurrency
     var eventLoop: any EventLoop { get }
     #endif
 
@@ -118,7 +118,7 @@ public protocol SQLDatabase: Sendable {
     ///   - query: An ``SQLExpression`` representing a complete query to execute.
     ///   - onRow: A closure which is invoked once for each result row returned by the query (if any).
     /// - Returns: An `EventLoopFuture`.
-    #if !hasFeature(Embedded)
+    #if !NativeConcurrency
     @preconcurrency
     func execute(
         sql query: any SQLExpression,
@@ -212,8 +212,9 @@ extension SQLDatabase {
 
 extension SQLDatabase {
     /// The default implementation for ``execute(sql:_:)-4eg19`` (bridges the legacy EventLoopFuture
-    /// API). On WASI there is no EventLoopFuture overload, so conformers implement async execute directly.
-    #if !hasFeature(Embedded)
+    /// API). On the NativeConcurrency build there is no EventLoopFuture overload, so conformers
+    /// implement async execute directly.
+    #if !NativeConcurrency
     @inlinable
     public func execute(
         sql query: any SQLExpression,
@@ -241,7 +242,7 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
     // See `SQLDatabase.logger`.
     let logger: Logger
     
-    #if !hasFeature(Embedded)
+    #if !NativeConcurrency
     // See `SQLDatabase.eventLoop`.
     var eventLoop: any EventLoop {
         self.database.eventLoop
@@ -263,7 +264,7 @@ private struct CustomLoggerSQLDatabase<D: SQLDatabase>: SQLDatabase {
         self.database.queryLogLevel
     }
     
-    #if !hasFeature(Embedded)
+    #if !NativeConcurrency
     // See `SQLDatabase.execute(sql:_:)`.
     func execute(
         sql query: any SQLExpression,

--- a/Sources/SQLKit/Database/SQLDatabaseReportedVersion.swift
+++ b/Sources/SQLKit/Database/SQLDatabaseReportedVersion.swift
@@ -88,12 +88,22 @@ extension SQLDatabaseReportedVersion {
     /// Default implementation of ``isEqual(to:)-6ybn8``.
     @inlinable
     public func isEqual(to otherVersion: any SQLDatabaseReportedVersion) -> Bool {
+        // `as? Self` is a cast to a generic type, unavailable in Embedded Swift; compare the string
+        // representations directly there (the same-type guard is relaxed).
+        #if hasFeature(Embedded)
+        otherVersion.stringValue == self.stringValue
+        #else
         (otherVersion as? Self).map { $0.stringValue == self.stringValue } ?? false
+        #endif
     }
 
     /// Default implementation of ``isOlder(than:)-1o58v``.
     @inlinable
     public func isOlder(than otherVersion: any SQLDatabaseReportedVersion) -> Bool {
+        #if hasFeature(Embedded)
+        self.stringValue.lexicographicallyPrecedes(otherVersion.stringValue)
+        #else
         (otherVersion as? Self).map { self.stringValue.lexicographicallyPrecedes($0.stringValue) } ?? false
+        #endif
     }
 }

--- a/Sources/SQLKit/Deprecated/SQLDatabase+Deprecated.swift
+++ b/Sources/SQLKit/Deprecated/SQLDatabase+Deprecated.swift
@@ -9,7 +9,13 @@ extension SQLDatabaseReportedVersion {
     @inlinable
     @available(*, deprecated, renamed: "<=", message: "Use the `<=` operator instead.")
     public func isNotNewer(than otherVersion: any SQLDatabaseReportedVersion) -> Bool {
+        // `as? Self` is a cast to a generic type (unavailable in Embedded Swift); call the
+        // existential-based comparisons directly there.
+        #if hasFeature(Embedded)
+        self.isEqual(to: otherVersion) || self.isOlder(than: otherVersion)
+        #else
         (otherVersion as? Self).map { self.isEqual(to: $0) || self.isOlder(than: $0) } ?? false
+        #endif
     }
     
     /// Check whether the current version (i.e. `self`) is newer than the one given.
@@ -22,7 +28,11 @@ extension SQLDatabaseReportedVersion {
     @inlinable
     @available(*, deprecated, renamed: ">", message: "Use the `>` operator instead.")
     public func isNewer(than otherVersion: any SQLDatabaseReportedVersion) -> Bool {
+        #if hasFeature(Embedded)
+        !self.isNotNewer(than: otherVersion)
+        #else
         (otherVersion as? Self).map { !self.isNotNewer(than: $0) } ?? false
+        #endif
     }
 
     /// Check whether the current version (i.e. `self`) is newer than or equal to the one given.
@@ -35,6 +45,10 @@ extension SQLDatabaseReportedVersion {
     @inlinable
     @available(*, deprecated, renamed: ">=", message: "Use the `>=` operator instead.")
     public func isNotOlder(than otherVersion: any SQLDatabaseReportedVersion) -> Bool {
+        #if hasFeature(Embedded)
+        !self.isOlder(than: otherVersion)
+        #else
         (otherVersion as? Self).map { !self.isOlder(than: $0) } ?? false
+        #endif
     }
 }

--- a/Sources/SQLKit/Deprecated/SQLExpressions+Deprecated.swift
+++ b/Sources/SQLKit/Deprecated/SQLExpressions+Deprecated.swift
@@ -75,7 +75,7 @@ extension SQLQueryString {
 extension SQLRaw {
     @available(*, deprecated, message: "Binds set in an `SQLRaw` are ignored. Use `SQLBind`instead.")
     @inlinable
-    public init(_ sql: String, _ binds: [any Encodable & Sendable]) {
+    public init(_ sql: String, _ binds: [any SQLBindable & Sendable]) {
         self.sql = sql
         self.binds = binds
     }

--- a/Sources/SQLKit/Deprecated/SQLQueryBuilders+Deprecated.swift
+++ b/Sources/SQLKit/Deprecated/SQLQueryBuilders+Deprecated.swift
@@ -39,7 +39,7 @@ extension SQLCreateTriggerBuilder {
     @inlinable
     @discardableResult
     public func body(_ statements: [String]) -> Self {
-        self.body(statements.map { SQLRaw($0) })
+        self.body(statements.map { SQLRaw($0) as any SQLExpression })
     }
 }
 

--- a/Sources/SQLKit/Exports.swift
+++ b/Sources/SQLKit/Exports.swift
@@ -1,3 +1,6 @@
+// EventLoop/EventLoopFuture are SwiftNIO types, elided on WASI (the WASI build is NIO-free / async).
+#if !hasFeature(Embedded)
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
+#endif
 @_documentation(visibility: internal) @_exported import struct Logging.Logger

--- a/Sources/SQLKit/Exports.swift
+++ b/Sources/SQLKit/Exports.swift
@@ -1,5 +1,5 @@
-// EventLoop/EventLoopFuture are SwiftNIO types, elided on WASI (the WASI build is NIO-free / async).
-#if !hasFeature(Embedded)
+// EventLoop/EventLoopFuture are SwiftNIO types, elided on the NativeConcurrency (NIO-free) build.
+#if !NativeConcurrency
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
 #endif

--- a/Sources/SQLKit/Expressions/Basics/SQLBetween.swift
+++ b/Sources/SQLKit/Expressions/Basics/SQLBetween.swift
@@ -47,9 +47,9 @@ extension SQLBetween {
     /// Create a ``SQLBetween`` expression from three bindable values.
     @inlinable
     public init(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) where T == SQLBind, U == SQLBind, V == SQLBind {
         self.init(operand: .init(operand), lowerBound: .init(lowerBound), upperBound: .init(upperBound))
     }
@@ -57,7 +57,7 @@ extension SQLBetween {
     /// Create an ``SQLBetween`` expression from a bindable value and two ``SQLExpression``s.
     @inlinable
     public init(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: U,
         and upperBound: V
     ) where T == SQLBind {
@@ -68,7 +68,7 @@ extension SQLBetween {
     @inlinable
     public init(
         _ operand: T,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: V
     ) where U == SQLBind {
         self.init(operand: operand, lowerBound: .init(lowerBound), upperBound: upperBound)
@@ -79,7 +79,7 @@ extension SQLBetween {
     public init(
         _ operand: T,
         between lowerBound: U,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) where V == SQLBind {
         self.init(operand: operand, lowerBound: lowerBound, upperBound: .init(upperBound))
     }
@@ -87,8 +87,8 @@ extension SQLBetween {
     /// Create an ``SQLBetween`` expression from two bindable values and an ``SQLExpression``.
     @inlinable
     public init(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: V
     ) where T == SQLBind, U == SQLBind {
         self.init(operand: .init(operand), lowerBound: .init(lowerBound), upperBound: upperBound)
@@ -98,8 +98,8 @@ extension SQLBetween {
     @inlinable
     public init(
         _ operand: T,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) where U == SQLBind, V == SQLBind {
         self.init(operand: operand, lowerBound: .init(lowerBound), upperBound: .init(upperBound))
     }
@@ -107,9 +107,9 @@ extension SQLBetween {
     /// Create an ``SQLBetween`` expression from a bindable value, an ``SQLExpression``, and a bindable value.
     @inlinable
     public init(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: U,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) where T == SQLBind, V == SQLBind {
         self.init(operand: .init(operand), lowerBound: lowerBound, upperBound: .init(upperBound))
     }
@@ -118,8 +118,8 @@ extension SQLBetween {
     @inlinable
     public init(
         column: String,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) where T == SQLIdentifier, U == SQLBind, V == SQLBind {
         self.init(operand: .init(column), lowerBound: .init(lowerBound), upperBound: .init(upperBound))
     }
@@ -128,7 +128,7 @@ extension SQLBetween {
     @inlinable
     public init(
         column: String,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: V
     ) where T == SQLIdentifier, U == SQLBind {
         self.init(operand: .init(column), lowerBound: .init(lowerBound), upperBound: upperBound)
@@ -139,7 +139,7 @@ extension SQLBetween {
     public init(
         column: String,
         between lowerBound: U,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) where T == SQLIdentifier, V == SQLBind {
         self.init(operand: .init(column), lowerBound: lowerBound, upperBound: .init(upperBound))
     }
@@ -162,9 +162,9 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func `where`(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.where(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -174,8 +174,8 @@ extension SQLPredicateBuilder {
     @inlinable
     public func `where`(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.where(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -184,9 +184,9 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func `where`(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.where(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -195,8 +195,8 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func `where`(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.where(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -208,7 +208,7 @@ extension SQLPredicateBuilder {
     public func `where`(
         _ operand: some SQLExpression,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.where(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -218,7 +218,7 @@ extension SQLPredicateBuilder {
     @inlinable
     public func `where`(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.where(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -228,7 +228,7 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func `where`(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
         and upperBound: some SQLExpression
     ) -> Self {
@@ -251,8 +251,8 @@ extension SQLPredicateBuilder {
     @inlinable
     public func `where`(
         column: String,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.where(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: SQLBind(upperBound)))
     }
@@ -262,7 +262,7 @@ extension SQLPredicateBuilder {
     @inlinable
     public func `where`(
         column: String,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.where(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: upperBound))
@@ -274,7 +274,7 @@ extension SQLPredicateBuilder {
     public func `where`(
         column: String,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.where(SQLBetween(operand: SQLColumn(column), lowerBound: lowerBound, upperBound: SQLBind(upperBound)))
     }
@@ -294,9 +294,9 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func orWhere(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orWhere(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -306,8 +306,8 @@ extension SQLPredicateBuilder {
     @inlinable
     public func orWhere(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orWhere(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -316,9 +316,9 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func orWhere(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orWhere(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -327,8 +327,8 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func orWhere(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.orWhere(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -340,7 +340,7 @@ extension SQLPredicateBuilder {
     public func orWhere(
         _ operand: some SQLExpression,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orWhere(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -350,7 +350,7 @@ extension SQLPredicateBuilder {
     @inlinable
     public func orWhere(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.orWhere(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -360,7 +360,7 @@ extension SQLPredicateBuilder {
     @discardableResult
     @inlinable
     public func orWhere(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
         and upperBound: some SQLExpression
     ) -> Self {
@@ -383,8 +383,8 @@ extension SQLPredicateBuilder {
     @inlinable
     public func orWhere(
         column: String,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orWhere(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: SQLBind(upperBound)))
     }
@@ -394,7 +394,7 @@ extension SQLPredicateBuilder {
     @inlinable
     public func orWhere(
         column: String,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.orWhere(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: upperBound))
@@ -406,7 +406,7 @@ extension SQLPredicateBuilder {
     public func orWhere(
         column: String,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orWhere(SQLBetween(operand: SQLColumn(column), lowerBound: lowerBound, upperBound: SQLBind(upperBound)))
     }
@@ -430,9 +430,9 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func having(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.having(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -442,8 +442,8 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func having(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.having(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -452,9 +452,9 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func having(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.having(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -463,8 +463,8 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func having(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.having(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -476,7 +476,7 @@ extension SQLSecondaryPredicateBuilder {
     public func having(
         _ operand: some SQLExpression,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.having(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -486,7 +486,7 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func having(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.having(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -496,7 +496,7 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func having(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
         and upperBound: some SQLExpression
     ) -> Self {
@@ -519,8 +519,8 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func having(
         column: String,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.having(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: SQLBind(upperBound)))
     }
@@ -530,7 +530,7 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func having(
         column: String,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.having(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: upperBound))
@@ -542,7 +542,7 @@ extension SQLSecondaryPredicateBuilder {
     public func having(
         column: String,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.having(SQLBetween(operand: SQLColumn(column), lowerBound: lowerBound, upperBound: SQLBind(upperBound)))
     }
@@ -562,9 +562,9 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func orHaving(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orHaving(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -574,8 +574,8 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func orHaving(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orHaving(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -584,9 +584,9 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func orHaving(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orHaving(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -595,8 +595,8 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func orHaving(
-        _ operand: some Encodable & Sendable,
-        between lowerBound: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.orHaving(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -608,7 +608,7 @@ extension SQLSecondaryPredicateBuilder {
     public func orHaving(
         _ operand: some SQLExpression,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orHaving(SQLBetween(operand, between: lowerBound, and: upperBound))
     }
@@ -618,7 +618,7 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func orHaving(
         _ operand: some SQLExpression,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.orHaving(SQLBetween(operand, between: lowerBound, and: upperBound))
@@ -628,7 +628,7 @@ extension SQLSecondaryPredicateBuilder {
     @discardableResult
     @inlinable
     public func orHaving(
-        _ operand: some Encodable & Sendable,
+        _ operand: some SQLBindable & Sendable,
         between lowerBound: some SQLExpression,
         and upperBound: some SQLExpression
     ) -> Self {
@@ -651,8 +651,8 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func orHaving(
         column: String,
-        between lowerBound: some Encodable & Sendable,
-        and upperBound: some Encodable & Sendable
+        between lowerBound: some SQLBindable & Sendable,
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orHaving(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: SQLBind(upperBound)))
     }
@@ -662,7 +662,7 @@ extension SQLSecondaryPredicateBuilder {
     @inlinable
     public func orHaving(
         column: String,
-        between lowerBound: some Encodable & Sendable,
+        between lowerBound: some SQLBindable & Sendable,
         and upperBound: some SQLExpression
     ) -> Self {
         self.orHaving(SQLBetween(operand: SQLColumn(column), lowerBound: SQLBind(lowerBound), upperBound: upperBound))
@@ -674,7 +674,7 @@ extension SQLSecondaryPredicateBuilder {
     public func orHaving(
         column: String,
         between lowerBound: some SQLExpression,
-        and upperBound: some Encodable & Sendable
+        and upperBound: some SQLBindable & Sendable
     ) -> Self {
         self.orHaving(SQLBetween(operand: SQLColumn(column), lowerBound: lowerBound, upperBound: SQLBind(upperBound)))
     }

--- a/Sources/SQLKit/Expressions/Basics/SQLDistinct.swift
+++ b/Sources/SQLKit/Expressions/Basics/SQLDistinct.swift
@@ -30,7 +30,7 @@ public struct SQLDistinct: SQLExpression {
     /// Create a `DISTINCT` expression with a list of string identifiers.
     @inlinable
     public init(_ args: [String]) {
-        self.init(args.map(SQLIdentifier.init(_:)))
+        self.init(args.map { SQLIdentifier($0) as any SQLExpression })
     }
     
     /// Create a `DISTINCT` expression with a list of expressions.

--- a/Sources/SQLKit/Expressions/Basics/SQLQueryString.swift
+++ b/Sources/SQLKit/Expressions/Basics/SQLQueryString.swift
@@ -118,7 +118,7 @@ extension SQLQueryString {
     ///
     /// This overload is provided as shorthand - `\(bind: "a")` is identical to `\(SQLBind("a"))`.
     @inlinable
-    public mutating func appendInterpolation(bind value: any Encodable & Sendable) {
+    public mutating func appendInterpolation(bind value: any SQLBindable & Sendable) {
         self.fragments.append(SQLBind(value))
     }
 
@@ -127,8 +127,8 @@ extension SQLQueryString {
     ///
     /// This overload is equivalent to `\(SQLList(values.map(SQLBind.init(_:))))`.
     @inlinable
-    public mutating func appendInterpolation(binds values: [any Encodable & Sendable]) {
-        self.fragments.append(SQLList(values.map { SQLBind($0) }))
+    public mutating func appendInterpolation(binds values: [any SQLBindable & Sendable]) {
+        self.fragments.append(SQLList(values.map { SQLBind($0) as any SQLExpression }))
     }
     
     /// Embed a `Bool` as a literal value, as if via ``SQLLiteral/boolean(_:)``.
@@ -180,7 +180,7 @@ extension SQLQueryString {
     /// ```
     @inlinable
     public mutating func appendInterpolation(literals: [String], joinedBy joiner: String) {
-        self.fragments.append(SQLList(literals.map { SQLLiteral.string($0) }, separator: SQLRaw(joiner)))
+        self.fragments.append(SQLList(literals.map { SQLLiteral.string($0) as any SQLExpression }, separator: SQLRaw(joiner)))
     }
 
     /// Embed a `String` as an identifier, as if via ``SQLIdentifier``.
@@ -210,7 +210,7 @@ extension SQLQueryString {
     /// ```
     @inlinable
     public mutating func appendInterpolation(idents: [String], joinedBy joiner: String) {
-        self.fragments.append(SQLList(idents.map { SQLIdentifier($0) }, separator: SQLRaw(joiner)))
+        self.fragments.append(SQLList(idents.map { SQLIdentifier($0) as any SQLExpression }, separator: SQLRaw(joiner)))
     }
 
     /// Embed an arbitary ``SQLExpression`` in the string.

--- a/Sources/SQLKit/Expressions/Clauses/SQLColumnAssignment.swift
+++ b/Sources/SQLKit/Expressions/Clauses/SQLColumnAssignment.swift
@@ -19,13 +19,13 @@ public struct SQLColumnAssignment: SQLExpression {
     
     /// Create a column assignment from a column identifier and value binding.
     @inlinable
-    public init(setting columnName: any SQLExpression, to value: any Encodable & Sendable) {
+    public init(setting columnName: any SQLExpression, to value: any SQLBindable & Sendable) {
         self.init(setting: columnName, to: SQLBind(value))
     }
 
     /// Create a column assignment from a column name and value binding.
     @inlinable
-    public init(setting columnName: String, to value: any Encodable & Sendable) {
+    public init(setting columnName: String, to value: any SQLBindable & Sendable) {
         self.init(setting: columnName, to: SQLBind(value))
     }
 

--- a/Sources/SQLKit/Expressions/Clauses/SQLColumnDefinition.swift
+++ b/Sources/SQLKit/Expressions/Clauses/SQLColumnDefinition.swift
@@ -45,7 +45,9 @@ public struct SQLColumnDefinition: SQLExpression {
         dataType: SQLDataType,
         constraints: [SQLColumnConstraintAlgorithm] = []
     ) {
-        self.init(column: SQLIdentifier(name), dataType: dataType, constraints: constraints)
+        // Box each element: the implicit `[SQLColumnConstraintAlgorithm]` → `[any SQLExpression]`
+        // conversion is a dynamic cast (`_arrayForceCast`), which Embedded Swift forbids.
+        self.init(column: SQLIdentifier(name), dataType: dataType, constraints: constraints.map { $0 as any SQLExpression })
     }
 
     // See `SQLExpression.serialize(to:)`.

--- a/Sources/SQLKit/Expressions/Clauses/SQLConflictResolutionStrategy.swift
+++ b/Sources/SQLKit/Expressions/Clauses/SQLConflictResolutionStrategy.swift
@@ -26,7 +26,7 @@ public struct SQLConflictResolutionStrategy: SQLExpression {
     /// Create a resolution strategy over the given column names and an action.
     @inlinable
     public init(targets targetColumns: [String], action: SQLConflictAction) {
-        self.init(targets: targetColumns.map { SQLColumn($0) }, action: action)
+        self.init(targets: targetColumns.map { SQLColumn($0) as any SQLExpression }, action: action)
     }
     
     /// Create a resolution strategy over the given column and an action.

--- a/Sources/SQLKit/Expressions/Clauses/SQLEnumDataType.swift
+++ b/Sources/SQLKit/Expressions/Clauses/SQLEnumDataType.swift
@@ -15,7 +15,7 @@ public struct SQLEnumDataType: SQLExpression {
     /// - Parameter cases: The list of cases in the enumeration.
     @inlinable
     public init(cases: [String]) {
-        self.init(cases: cases.map(SQLLiteral.string(_:)))
+        self.init(cases: cases.map { SQLLiteral.string($0) as any SQLExpression })
     }
 
     /// Create a new enumeration type with a list of cases.
@@ -59,7 +59,7 @@ extension SQLDataType {
     /// - Returns: An appropriate ``SQLDataType``.
     @inlinable
     public static func `enum`(_ cases: [String]) -> Self {
-        self.enum(cases.map(SQLLiteral.string(_:)))
+        self.enum(cases.map { SQLLiteral.string($0) as any SQLExpression })
     }
 
     /// Translates to an enumeration including the specified list of cases.

--- a/Sources/SQLKit/Expressions/Queries/SQLAlterTable.swift
+++ b/Sources/SQLKit/Expressions/Queries/SQLAlterTable.swift
@@ -49,7 +49,7 @@ public struct SQLAlterTable: SQLExpression {
         let syntax = serializer.dialect.alterTableSyntax
         
         if !syntax.allowsBatch,
-           [self.addColumns, self.modifyColumns, self.dropColumns, self.addTableConstraints, self.dropTableConstraints].map(\.count).reduce(0, +) > 1
+           [self.addColumns, self.modifyColumns, self.dropColumns, self.addTableConstraints, self.dropTableConstraints].map({ $0.count }).reduce(0, +) > 1
         {
             serializer.database.logger.debug("Database does not support multiple table operation per statement; perform multiple queries with one alteration each instead.")
             // Emit the query anyway so the error will propagate when the database rejects it.
@@ -60,8 +60,10 @@ public struct SQLAlterTable: SQLExpression {
             // Emit the query anyway so the error will propagate when the database rejects it.
         }
 
-        let additions = (self.addColumns  + self.addTableConstraints).map  { (verb: SQLRaw("ADD"),  definition: $0) }
-        let removals  = (self.dropColumns + self.dropTableConstraints).map { (verb: SQLRaw("DROP"), definition: $0) }
+        // Box `verb` to `any SQLExpression` so all three arrays share one tuple type; the implicit
+        // unification during concatenation below is otherwise a dynamic cast (forbidden in embedded).
+        let additions = (self.addColumns  + self.addTableConstraints).map  { (verb: SQLRaw("ADD")  as any SQLExpression, definition: $0) }
+        let removals  = (self.dropColumns + self.dropTableConstraints).map { (verb: SQLRaw("DROP") as any SQLExpression, definition: $0) }
         let modifications = self.modifyColumns.map { (verb: syntax.alterColumnDefinitionClause ?? SQLRaw("__INVALID__"), definition: $0) }
         let alterations = additions + removals + modifications
 

--- a/Sources/SQLKit/Expressions/Queries/SQLInsert.swift
+++ b/Sources/SQLKit/Expressions/Queries/SQLInsert.swift
@@ -90,7 +90,7 @@ public struct SQLInsert: SQLExpression {
             $0.append("INTO", self.table)
             $0.append(SQLGroupExpression(self.columns))
             if !self.values.isEmpty {
-                $0.append("VALUES", SQLList(self.values.map(SQLGroupExpression.init)))
+                $0.append("VALUES", SQLList(self.values.map { SQLGroupExpression($0) as any SQLExpression }))
             } else if let subquery = self.valueQuery {
                 $0.append(subquery)
             }

--- a/Sources/SQLKit/Expressions/SQLSerializer.swift
+++ b/Sources/SQLKit/Expressions/SQLSerializer.swift
@@ -5,7 +5,7 @@ public struct SQLSerializer: Sendable {
     public var sql: String
     
     /// The list of bound parameter values (if any).
-    public var binds: [any Encodable & Sendable]
+    public var binds: [any SQLBindable & Sendable]
     
     /// The database for this serializer.
     public let database: any SQLDatabase
@@ -30,7 +30,7 @@ public struct SQLSerializer: Sendable {
     ///
     /// - Parameter encodable: The value to bind.
     @inlinable
-    public mutating func write(bind encodable: any Encodable & Sendable) {
+    public mutating func write(bind encodable: any SQLBindable & Sendable) {
         self.binds.append(encodable)
         self.dialect.bindPlaceholder(at: self.binds.count)
             .serialize(to: &self)

--- a/Sources/SQLKit/Expressions/Syntax/SQLBind.swift
+++ b/Sources/SQLKit/Expressions/Syntax/SQLBind.swift
@@ -1,18 +1,18 @@
 /// A parameterizied value bound to the SQL query.
 public struct SQLBind: SQLExpression {
     /// The actual bound value.
-    public let encodable: any Encodable & Sendable
+    public let encodable: any SQLBindable & Sendable
     
     /// Create a binding to a value.
     @inlinable
-    public init(_ encodable: any Encodable & Sendable) {
+    public init(_ encodable: any SQLBindable & Sendable) {
         self.encodable = encodable
     }
     
     /// Create a list of bindings to an array of values, with the placeholders wrapped in an ``SQLGroupExpression``.
     @inlinable
-    public static func group(_ items: [any Encodable & Sendable]) -> any SQLExpression {
-        SQLGroupExpression(items.map(SQLBind.init))
+    public static func group(_ items: [any SQLBindable & Sendable]) -> any SQLExpression {
+        SQLGroupExpression(items.map { SQLBind($0) as any SQLExpression })
     }
 
     // See `SQLExpression.serialize(to:)`.

--- a/Sources/SQLKit/Expressions/Syntax/SQLBindValue.swift
+++ b/Sources/SQLKit/Expressions/Syntax/SQLBindValue.swift
@@ -1,0 +1,54 @@
+// SQLKit normally types bound-parameter values as `any Encodable`, letting the driver encode them via
+// Codable. Embedded Swift has no Codable, so on that target the bind-parameter type is switched to a
+// lightweight, driver-neutral `SQLBindValue` protocol. The `SQLBindable` typealias selects between the
+// two so the rest of SQLKit's expression/serializer layer is unchanged save for the type name.
+//
+// (The Codable *model* encode/decode features — `set(model:)`, `insert(models:)`, `decode(model:)` —
+// are separately gated out on embedded, since they fundamentally require Codable.)
+
+#if hasFeature(Embedded)
+/// A driver-neutral primitive value: the embedded substitute for whatever a driver would otherwise
+/// extract from an `Encodable` bound parameter. Drivers map these cases to their own value type.
+public enum SQLDataValue: Sendable {
+    case integer(Int64)
+    case double(Double)
+    case string(String)
+    case blob([UInt8])
+    case bool(Bool)
+    case null
+}
+
+/// The embedded substitute for `Encodable` as SQLKit's bound-parameter type.
+///
+/// On the embedded target, values bound into a query (e.g. `.where("x", .equal, 1)`) must conform to
+/// this protocol instead of `Encodable`. The standard primitive types conform out of the box.
+public protocol SQLBindValue: Sendable {
+    /// The driver-neutral representation of this value.
+    var sqlDataValue: SQLDataValue { get }
+}
+
+/// SQLKit's bound-parameter constraint. `SQLBindValue` in Embedded Swift; `Encodable` elsewhere.
+public typealias SQLBindable = SQLBindValue
+
+extension Int: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(self)) } }
+extension Int8: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(self)) } }
+extension Int16: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(self)) } }
+extension Int32: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(self)) } }
+extension Int64: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(self) } }
+extension UInt: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(bitPattern: UInt64(self))) } }
+extension UInt8: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(self)) } }
+extension UInt16: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(self)) } }
+extension UInt32: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(self)) } }
+extension UInt64: SQLBindValue { public var sqlDataValue: SQLDataValue { .integer(Int64(bitPattern: self)) } }
+extension Double: SQLBindValue { public var sqlDataValue: SQLDataValue { .double(self) } }
+extension Float: SQLBindValue { public var sqlDataValue: SQLDataValue { .double(Double(self)) } }
+extension String: SQLBindValue { public var sqlDataValue: SQLDataValue { .string(self) } }
+extension Bool: SQLBindValue { public var sqlDataValue: SQLDataValue { .bool(self) } }
+extension [UInt8]: SQLBindValue { public var sqlDataValue: SQLDataValue { .blob(self) } }
+extension Optional: SQLBindValue where Wrapped: SQLBindValue {
+    public var sqlDataValue: SQLDataValue { self?.sqlDataValue ?? .null }
+}
+#else
+/// SQLKit's bound-parameter constraint. `SQLBindValue` in Embedded Swift; `Encodable` elsewhere.
+public typealias SQLBindable = Encodable
+#endif

--- a/Sources/SQLKit/Expressions/Syntax/SQLFunction.swift
+++ b/Sources/SQLKit/Expressions/Syntax/SQLFunction.swift
@@ -31,7 +31,7 @@ public struct SQLFunction: SQLExpression {
     ///   - args: The list of arguments.
     @inlinable
     public init(_ name: String, args: String...) {
-        self.init(name, args: args.map { SQLIdentifier($0) })
+        self.init(name, args: args.map { SQLIdentifier($0) as any SQLExpression })
     }
     
     /// Create a function from a name and list of arguments.
@@ -43,7 +43,7 @@ public struct SQLFunction: SQLExpression {
     ///   - args: The list of arguments.
     @inlinable
     public init(_ name: String, args: [String]) {
-        self.init(name, args: args.map { SQLIdentifier($0) })
+        self.init(name, args: args.map { SQLIdentifier($0) as any SQLExpression })
     }
     
     /// Create a function from a name and list of arguments.

--- a/Sources/SQLKit/Expressions/Syntax/SQLRaw.swift
+++ b/Sources/SQLKit/Expressions/Syntax/SQLRaw.swift
@@ -21,7 +21,7 @@ public struct SQLRaw: SQLExpression {
     /// functionality was never properly implemented and was never used, and is deprecated. Use ``SQLBind`` and/or
     /// ``SQLQueryString`` to achieve the same effect.
     @available(*, deprecated, message: "Binds set in an `SQLRaw` are ignored. Use `SQLBind` instead.")
-    public var binds: [any Encodable & Sendable] = []
+    public var binds: [any SQLBindable & Sendable] = []
     
     /// Create a new raw SQL text expression.
     ///

--- a/Sources/SQLKit/Rows/SQLCodingUtilities.swift
+++ b/Sources/SQLKit/Rows/SQLCodingUtilities.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)  // EMBEDDED-WASI: Codable engine; Encoder/Decoder unavailable in Embedded Swift
 /// Errors raised by ``SQLRowDecoder`` and ``SQLQueryEncoder``.
 @_spi(CodableUtilities)
 public enum SQLCodingError: Error, CustomStringConvertible, Sendable {
@@ -237,3 +238,5 @@ extension FakeSendableCodable: CustomDebugStringConvertible where T: CustomDebug
         self.value.debugDescription
     }
 }
+
+#endif  // !hasFeature(Embedded)

--- a/Sources/SQLKit/Rows/SQLQueryEncoder.swift
+++ b/Sources/SQLKit/Rows/SQLQueryEncoder.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)  // EMBEDDED-WASI: Codable engine; Encoder/Decoder unavailable in Embedded Swift
 import struct OrderedCollections.OrderedDictionary
 
 /// An implementation of `Encoder` designed to encode "models" (or, in general, aggregate `Encodable` types) into a
@@ -427,3 +428,5 @@ public struct SQLQueryEncoder: Sendable {
         }
     }
 }
+
+#endif  // !hasFeature(Embedded)

--- a/Sources/SQLKit/Rows/SQLRow.swift
+++ b/Sources/SQLKit/Rows/SQLRow.swift
@@ -29,9 +29,15 @@ public protocol SQLRow: Sendable {
     /// does not exist in the row.
     ///
     /// Corresponds to `KeyedDecodingContainer.decode(_:forKey:)`.
+    ///
+    /// Unavailable in Embedded Swift: it is a generic method requirement (which can't be placed in a
+    /// witness table, so it would block `any SQLRow`) and relies on `Decodable`.
+    #if !hasFeature(Embedded)
     func decode<D: Decodable>(column: String, as: D.Type) throws -> D
+    #endif
 }
 
+#if !hasFeature(Embedded)
 extension SQLRow {
     /// Decode an entire `Decodable` "model" type at once, optionally applying a prefix and/or
     /// ``SQLRowDecoder/KeyDecodingStrategy-swift.enum`` to the type's coding keys.
@@ -88,3 +94,4 @@ extension SQLRow {
         try self.decode(column: column, as: D.self)
     }
 }
+#endif  // !hasFeature(Embedded)

--- a/Sources/SQLKit/Rows/SQLRowDecoder.swift
+++ b/Sources/SQLKit/Rows/SQLRowDecoder.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)  // EMBEDDED-WASI: Codable engine; Encoder/Decoder unavailable in Embedded Swift
 /// An implementation of `Decoder` designed to decode "models" (or, in general, aggregate `Decodable` types) from
 /// ``SQLRow``s returned from a database query.
 ///
@@ -397,3 +398,5 @@ public struct SQLRowDecoder: Sendable {
         }
     }
 }
+
+#endif  // !hasFeature(Embedded)

--- a/Sources/SQLKit/Utilities/SomeCodingKey.swift
+++ b/Sources/SQLKit/Utilities/SomeCodingKey.swift
@@ -1,3 +1,4 @@
+#if !hasFeature(Embedded)  // EMBEDDED-WASI: CodingKey unavailable in Embedded Swift
 /// A straightforward implementation of `CodingKey`, used to represent arbitrary keys.
 ///
 /// This type is a simple helper, compensating for the inability to depend on the presence
@@ -30,3 +31,5 @@ public struct SomeCodingKey: CodingKey, Hashable, Sendable {
         self.intValue = intValue
     }
 }
+
+#endif  // !hasFeature(Embedded)

--- a/Sources/SQLKit/Utilities/StringHandling.swift
+++ b/Sources/SQLKit/Utilities/StringHandling.swift
@@ -20,12 +20,12 @@ extension StringProtocol where Self: RangeReplaceableCollection, Self.Element: E
     }
 
     /// Provides a version of `StringProtocol.replacing(_:with:)` which is guaranteed to be available.
-    #if !DEBUG && !canImport(Darwin)
+    #if !DEBUG && !canImport(Darwin) && !hasFeature(Embedded)
     @inline(__always)
     #endif
     @inlinable
     func sqlkit_replacing(_ search: some StringProtocol, with replacement: some StringProtocol) -> String {
-        #if DEBUG || canImport(Darwin)
+        #if DEBUG || canImport(Darwin) || hasFeature(Embedded)
         // On Apple platforms, this hand-rolled implementation is MUCH faster (10x or more) than the stdlib version, for some reason.
         // We also want to use this implementation in debug builds, so that the tests test it rather than the stdlib.
         guard !self.isEmpty, !search.isEmpty, self.count >= search.count else { return .init(self) }
@@ -136,7 +136,9 @@ extension StringProtocol where Self: RangeReplaceableCollection, Self.Element: E
     /// - Returns: The string with the prefix removed, if it exists. The string unmodified if not,
     ///   or if `prefix` is `nil`.
     func drop(prefix: (some StringProtocol)?) -> Self.SubSequence {
-        #if !DEBUG
+        // Embedded: `trimmingPrefix(_:)` is not available in the Embedded stdlib;
+        // fall through to the manual implementation below.
+        #if !DEBUG && !hasFeature(Embedded)
         if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
             return prefix.map(self.trimmingPrefix(_:)) ?? self[...]
         }

--- a/Sources/SQLKit/Utilities/StringHandling.swift
+++ b/Sources/SQLKit/Utilities/StringHandling.swift
@@ -117,6 +117,8 @@ extension StringProtocol where Self: RangeReplaceableCollection, Self.Element: E
     }
     
     /// A necessarily inelegant polyfill for conformance to `CodingKeyRepresentable`, due to availability problems.
+    /// `CodingKey` is unavailable in Embedded Swift.
+    #if !hasFeature(Embedded)
     @inlinable
     var codingKeyValue: any CodingKey {
         #if !DEBUG
@@ -126,6 +128,7 @@ extension StringProtocol where Self: RangeReplaceableCollection, Self.Element: E
         #endif
         return SomeCodingKey(stringValue: .init(self))
     }
+    #endif
     
     /// Remove the given optional prefix from the string, if present.
     ///

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Codable.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Codable.swift
@@ -1,3 +1,4 @@
+#if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import SQLKit
 
 extension SQLBenchmarker {
@@ -44,3 +45,5 @@ fileprivate struct Galaxy: Encodable {
     let id: Int? = nil
     let name: String
 }
+
+#endif // !os(WASI)

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Enum.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Enum.swift
@@ -1,3 +1,4 @@
+#if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import SQLKit
 
 extension SQLBenchmarker {
@@ -116,3 +117,5 @@ private enum PlanetType: String, Codable, SQLExpression {
             .serialize(to: &serializer)
     }
 }
+
+#endif // !os(WASI)

--- a/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+JSONPaths.swift
@@ -1,3 +1,4 @@
+#if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import SQLKit
 import XCTest
 
@@ -45,3 +46,5 @@ extension SQLBenchmarker {
         }
     }
 }
+
+#endif // !os(WASI)

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Planets.swift
@@ -1,3 +1,4 @@
+#if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import XCTest
 import SQLKit
 
@@ -112,3 +113,5 @@ extension SQLBenchmarker {
         }
     }
 }
+
+#endif // !os(WASI)

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Union.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Union.swift
@@ -1,3 +1,4 @@
+#if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import XCTest
 import SQLKit
 
@@ -193,3 +194,5 @@ extension SQLBenchmarker {
         }
     }
 }
+
+#endif // !os(WASI)

--- a/Sources/SQLKitBenchmark/SQLBenchmark+Upsert.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmark+Upsert.swift
@@ -1,3 +1,4 @@
+#if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import XCTest
 import SQLKit
 
@@ -178,3 +179,5 @@ extension SQLBenchmarker {
         }
     }
 }
+
+#endif // !os(WASI)

--- a/Sources/SQLKitBenchmark/SQLBenchmarker.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmarker.swift
@@ -1,3 +1,4 @@
+#if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import Logging
 import NIOCore
 public import SQLKit
@@ -79,3 +80,5 @@ func XCTAssertNoThrowAsync<T>(
         XCTAssertNoThrow(try { throw error }(), message(), file: file, line: line)
     }
 }
+
+#endif // !os(WASI)

--- a/Sources/SQLKitBenchmark/SQLBenchmarker.swift
+++ b/Sources/SQLKitBenchmark/SQLBenchmarker.swift
@@ -1,6 +1,8 @@
 #if !os(WASI) // XCTest & Codable are unavailable on the embedded WASI toolchain.
 import Logging
+#if !NativeConcurrency
 import NIOCore
+#endif
 public import SQLKit
 import XCTest
 
@@ -22,6 +24,8 @@ public final class SQLBenchmarker: Sendable {
         }
     }
     
+    // The deprecated EventLoopFuture bridges are elided on the NativeConcurrency (NIO-free) build.
+    #if !NativeConcurrency
     @available(*, deprecated, renamed: "runAllTests()", message: "Use `runAllTests()` instead.")
     public func testAll() throws {
         try database.eventLoop.makeFutureWithTask { try await self.runAllTests() }.wait()
@@ -31,6 +35,7 @@ public final class SQLBenchmarker: Sendable {
     public func run() throws {
         try self.testAll()
     }
+    #endif
     
     func runTest(
         _ name: String = #function,


### PR DESCRIPTION
## What

Adds a `NativeConcurrency` package trait to SQLKit: an opt-in, async-only, NIO-free flavor of the query-builder surface.

- **Traits manifest** (Swift 6.1+): declares `NIO` (member of the default trait set), `NativeConcurrency`, and `Freestanding`. Pre-6.1 toolchains never see the versioned manifest and keep resolving the plain `Package.swift`, so nothing changes for them.
- **`NIO` stays the default trait**: a consumer that specifies nothing gets the existing `EventLoopFuture`-returning API, byte-identical to today.
- **`--traits NativeConcurrency`** re-keys the sources (`#if NativeConcurrency`): `SQLQueryBuilder`/`SQLQueryFetcher` run paths and `SQLDatabase` become `async`-only, and the NIO re-exports are dropped, removing the swift-nio dependency surface from the flavor entirely.

## Why

Staged fork-internally ahead of a possible upstream proposal: it lets Swift-concurrency-native (and Embedded/WASI-leaning) consumers use SQLKit without any NIO linkage while keeping one source tree, selected purely through SwiftPM package traits.

## Verification

- Default flavor: `swift build` and `swift test` green — the default (`NIO`) trait build is unchanged behavior.
- `swift build --traits NativeConcurrency`: green, with no `EventLoopFuture`/NIO surface in the flavor's API.

## Branch shape

Base is a fork branch cut at exactly the upstream 3.36.0 revision khasm pins (`base/khasm-pin-3.36.0`), so the diff is precisely this work. The head carries the two fork-internal Embedded-gating commits the trait conversion textually builds on (Embedded-only gating rebased onto 3.36.0, plus `trimmingPrefix`/inline-heuristic gates), topped by the trait conversion commit itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
